### PR TITLE
Member signup

### DIFF
--- a/MemberLifecycle.md
+++ b/MemberLifecycle.md
@@ -17,6 +17,25 @@ The requirements to vogelnest in this process are:
     - notify ppl to activate the user
     - invite the user to choose a password
     - reflect the newly choosen username back to CiviCRM; CiviCRM will save the mail adress in the SOG domain
+
+### Technical Documentation
+
+CiviCRM drops a request to the endpoint *create_user* using POST.
+The following info shall be delivered in a JSON body:
+  - First Name
+  - Last Name
+  - E-Mail
+  - Lokalgruppe (prefixed lowercase, like lg_aachen or lg_berlin)
+
+Since only Civi may create users, the request has to be authenticated
+by HTTP basic auth.
+Username: *civicrm*
+Password: As specified in CIVICRM_SECRET
+
+This app will generate a username and return it as plain text
+in the response body.
+
+This app will issue error 500 if user creation is not possible.
     
 ## Other requirements in the member lifecycle
 - Changes in the alternative e mail adress shall be reflected (see #28)

--- a/app.py
+++ b/app.py
@@ -64,6 +64,13 @@ def create_user():
     lastName = sanitize(request.json.get('lastName'))
     email = sanitize(request.json.get('email'))
     lokalgruppe = sanitize(request.json.get('lokalgruppe')) #like lg_aachen
+
+    # Abort 500 if lokalgruppe does not exist
+    try:
+        api.get_group(lokalgruppe)
+    except:
+        abort(500, "lokalgruppe " + lokalgruppe " does not exist")
+
     try:
         username = api.create_member(firstName, lastName,email)
 
@@ -76,7 +83,7 @@ def create_user():
         })
 
         # request membership in LG. Is non existent LG be dealt with correctly? 
-        group_request_handler.request_inactive_pending(api,lokalgruppe,username)
+        group_request_handler.request_inactive_pending(api, lokalgruppe, username)
         # Person becomes member of allgemein upon activation
 
         return username

--- a/app.py
+++ b/app.py
@@ -67,11 +67,11 @@ def create_user():
         username = api.create_member(firstName, lastName,email)
 
         # Mail fuer Passwort muss raus
-        password_reset_token = token_handler.create_password_reset_jwt_token(username).decode("utf-8")
+        password_reset_token = token_handler.create_initial_confirmation_jwt_token(username, email).decode("utf-8")
         mail.send_email(email, "Willkommen bei SOG!", "emails/new_user_onboarding", {
             "firstName" : firstName,
             "name": username,
-            "link": join(config.FRONTEND_URL, "confirm/password?key=" + password_reset_token),
+            "link": join(config.FRONTEND_URL, "confirm?key=" + password_reset_token),
         })
 
         # Anfrage auf SOG Mitgliedschaft und auf Gruppenmitgliedschaft in LG     

--- a/app.py
+++ b/app.py
@@ -68,7 +68,8 @@ def create_user():
 
         # Mail fuer Passwort muss raus
         password_reset_token = token_handler.create_password_reset_jwt_token(username).decode("utf-8")
-        mail.send_email(email, "Passwort-Reset", "emails/password_reset_email", {
+        mail.send_email(email, "Willkommen bei SOG!", "emails/new_user_onboarding", {
+            "firstName" : firstName,
             "name": username,
             "link": join(config.FRONTEND_URL, "confirm/password?key=" + password_reset_token),
         })

--- a/app.py
+++ b/app.py
@@ -69,7 +69,7 @@ def create_user():
     try:
         api.get_group(lokalgruppe)
     except:
-        abort(500, "lokalgruppe " + lokalgruppe " does not exist")
+        abort(500, "lokalgruppe " + lokalgruppe + " does not exist")
 
     try:
         username = api.create_member(firstName, lastName,email)

--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ from ldap_api import LdapApi, LdapApiException
 from ldap3.utils import conv
 from middleware import middleware
 import token_handler
+import group_request_handler
 from os.path import join
 from urllib.parse import unquote
 import jwt
@@ -489,17 +490,7 @@ def request_access_to_group(group_id):
         return abort(401)
     if not api.is_active(my_uid):
         return abort(401)
-    api.add_group_active_pending_member(group_id, my_uid)
-    group = api.get_group(group_id)
-    user = api.get_user(my_uid)
-    for owner in api.get_group_owners(group_id):
-        mail.send_email(str(owner.mail), "Neue Anfrage in " + str(group.cn), \
-               "emails/new_pending_member_mail", {
-                   "name": str(owner.cn),
-                   "group_name": str(group.cn),
-                   "dashboard_url": config.FRONTEND_URL,
-                   "new_member_name": str(user.cn)
-               })
+    group_request_handler.request_active_pending(api, group_id, my_uid)
     return "ok"
 
 @app.route('/groups/<group_id>/accept_pending_member', methods=['POST'])

--- a/config.sample.py
+++ b/config.sample.py
@@ -27,3 +27,5 @@ MAIL_ADDRESS = ''
 MAIL_SERVER = ''
 MAIL_PASSWORD = ''
 
+# Token used by civi to authenticate its requests
+CIVICRM_SECRET = ''

--- a/emails/new_lg_member.html
+++ b/emails/new_lg_member.html
@@ -1,0 +1,8 @@
+<p>Hallo,</p>
+
+<p>Soeben hat sich {new_member_name} für Deine Lokalgruppe {group_name} angemeldet.
+Das neue Mitglied ist schon auf dem Lokalgruppen-Verteiler eingetragen und hat einen Account erhalten.</p>
+<p><strong>Achtung:</strong> Der SOG-Account des Mitglieds muss erst von dir aktiviert werden.</p>
+<p>Bitte bestätige am Besten jetzt <a href='{dashboard_url}'>direkt im Vogelnest</a>, dass {new_member_name} tatsächlich in eurer LG aktiv ist!</p>
+<p>Viele Grüße,</p>
+<p>Das SOG Vogelnest</p>

--- a/emails/new_lg_member.txt
+++ b/emails/new_lg_member.txt
@@ -1,0 +1,13 @@
+Hallo,
+
+Soeben hat sich {new_member_name} für Deine Lokalgruppe {group_name} angemeldet.
+Das neue Mitglied ist schon auf dem Lokalgruppen-Verteiler eingetragen und hat einen Account erhalten.
+Achtung: Der SOG-Account des Mitglieds muss erst von dir aktiviert werden.
+
+Bitte bestätige am Besten jetzt direkt im Vogelnest, dass {new_member_name} tatsächlich in eurer LG aktiv ist:
+
+{dashboard_url}
+
+Viele Grüße,
+
+Das SOG Vogelnest

--- a/emails/new_user_onboarding.html
+++ b/emails/new_user_onboarding.html
@@ -1,0 +1,12 @@
+<p>Hallo {firstName},</p>
+<p>Wir freuen uns sehr, dich als neues Mitglied bei Studieren Ohne Grenzen begrüßen zu dürfen.</p>
+<p>Damit du direkt einsteigen und mitarbeiten kannst, haben wir dir automatisch einen Zugang für unsere Online-Plattformen erstellt. Über diese Plattformen tauschen wir wichtige Nachrichten, Informationen und Dateien aus und diskutieren auch Lokalgruppen-übergreifend.</p>
+<p>Benutzername ist: {name}</p>
+<p>Bitte öffne folgenden Link, um deine Mailadresse zu bestätigen und ein Passwort zu vergeben:
+<a href="{link}">Account bestätigen</a></p>
+<p>Dein Account wird freigeschaltet, sobald dein Lokalkoordinator:in bestätigt hat, dass du tatsächlich bei Studieren Ohne Grenzen aktiv bist.
+Mit deinem Benutzernamen und dem von dir vergebenen Passwort kannst du dich auf allen SOG-Systeme einloggen.</p>
+
+<p>Eine Übersicht deiner Daten und Gruppen gibt dir das Vogelnest: <a href="vogelnest.studieren-ohne-grenzen.org">vogelnest.studieren-ohne-grenzen.org</a></p>
+<p>Viele Grüße,</p>
+<p>Das SOG Vogelnest</p>

--- a/emails/new_user_onboarding.txt
+++ b/emails/new_user_onboarding.txt
@@ -1,0 +1,18 @@
+Hallo {firstName},
+
+Wir freuen uns sehr, dich als neues Mitglied bei Studieren Ohne Grenzen begrüßen zu dürfen.
+
+Damit du direkt einsteigen und mitarbeiten kannst, haben wir dir automatisch einen Zugang für unsere Online-Plattformen erstellt.
+Über diese Plattformen tauschen wir wichtige Nachrichten, Informationen und Dateien aus und diskutieren auch Lokalgruppen-übergreifend.
+
+Dein Benutzername ist: {name}
+Bitte öffne folgenden Link, um deine Mailadresse zu bestätigen und ein Passwort zu vergeben:
+{link}
+
+Dein Account wird freigeschaltet, sobald dein Lokalkoordinator:in bestätigt hat, dass du tatsächlich bei Studieren Ohne Grenzen aktiv bist.
+
+Mit deinem Benutzernamen und dem von dir vergebenen Passwort kannst du dich auf allen SOG-Systeme einloggen.
+
+Eine Übersicht deiner Daten und Gruppen gibt dir das Vogelnest: vogelnest.studieren-ohne-grenzen.org
+Viele Grüße,
+Das SOG Vogelnest

--- a/group_request_handler.py
+++ b/group_request_handler.py
@@ -13,3 +13,15 @@ def request_active_pending(api, group_id, my_uid):
                    "dashboard_url": config.FRONTEND_URL,
                    "new_member_name": str(user.cn)
                })
+
+def request_inactive_pending(api, group_id, my_uid):
+    api.add_group_inactive_pending_member(group_id, my_uid)
+    group = api.get_group(group_id)
+    user = api.get_inactive_user(my_uid) 
+    for owner in api.get_group_owners(group_id):
+        mail.send_email(str(owner.mail), "Neue Anfrage in " + str(group.cn), \
+               "emails/new_lg_member", {
+                   "group_name": str(group.cn),
+                   "dashboard_url": config.FRONTEND_URL,
+                   "new_member_name": str(user.cn)
+               })

--- a/group_request_handler.py
+++ b/group_request_handler.py
@@ -1,0 +1,15 @@
+import mail
+import config
+
+def request_active_pending(api, group_id, my_uid):
+    api.add_group_active_pending_member(group_id, my_uid)
+    group = api.get_group(group_id)
+    user = api.get_user(my_uid)
+    for owner in api.get_group_owners(group_id):
+        mail.send_email(str(owner.mail), "Neue Anfrage in " + str(group.cn), \
+               "emails/new_pending_member_mail", {
+                   "name": str(owner.cn),
+                   "group_name": str(group.cn),
+                   "dashboard_url": config.FRONTEND_URL,
+                   "new_member_name": str(user.cn)
+               })

--- a/ldap_api.py
+++ b/ldap_api.py
@@ -153,6 +153,7 @@ class LdapApi():
         username = self.generate_username("%s.%s" % (firstName, lastName))  
         dn = self.get_inactive_person_dn(username)
         sog_mail = username + "@studieren-ohne-grenzen.org"
+        sog_alias = username + "@s-o-g.org"
         self.conn.add(dn, [
             'person',
             'sogperson',
@@ -168,7 +169,7 @@ class LdapApi():
             'givenName': firstName,
             'sn': lastName,
             'mail': sog_mail,
-            'mailAlias': sog_mail,
+            'mailAlias': sog_alias,
             'mail-alternative': mail,
             'mailHomeDirectory': '/srv/vmail/%s' % sog_mail,
             'mailStorageDirectory': 'maildir:/srv/vmail/%s/Maildir' % sog_mail,

--- a/ldap_api.py
+++ b/ldap_api.py
@@ -254,6 +254,11 @@ class LdapApi():
         self.conn.search(self.config.DN_GROUPS, '(&(objectClass=groupOfNames)(pending=%s))' % user_dn, attributes=GROUP_ATTRIBUTES_PENDING)
         return self.conn.entries
 
+    def add_group_inactive_pending_member(self, group, uid):
+        group_dn = self.get_group_dn(group)
+        user_dn = self.find_inactive_user_dn(uid)
+        self.conn.modify(group_dn, {'pending': [(MODIFY_ADD, [user_dn])]})
+
     def add_group_active_pending_member(self, group, uid):
         group_dn = self.get_group_dn(group)
         user_dn = self.find_user_dn(uid)

--- a/middleware.py
+++ b/middleware.py
@@ -14,9 +14,8 @@ class middleware():
         authheader = request.headers.get('Authorization')
 
         uid = token_handler.get_jwt_user(authheader)
-        print(request.url.replace(request.url_root, ""))
         if uid == None and \
-                not request.url.replace(request.url_root, "") in ["login", "users/reset_password", "users/set_password_with_key"] and \
+                not request.url.replace(request.url_root, "") in ["login", "users/reset_password", "users/set_password_with_key", "create_user"] and \
                 not request.url.replace(request.url_root, "").startswith("confirm"): 
             res = Response(u'Authorization failed', mimetype= 'text/plain', status=401)
             return res(environ, start_response)

--- a/token_handler.py
+++ b/token_handler.py
@@ -24,6 +24,14 @@ def create_password_reset_jwt_token(username):
         'exp': datetime.datetime.utcnow() + datetime.timedelta(minutes=30)
     }, config.JWT_SECRET, algorithm='HS256')
 
+def create_initial_confirmation_jwt_token(username, email):
+    return jwt.encode({
+        'type': 'initial_confirmation',
+        'username': username,
+        'email': email,
+        'exp': datetime.datetime.utcnow() + datetime.timedelta(minutes=30)
+    }, config.JWT_SECRET, algorithm='HS256')
+
 # checks header and returns username if header is valid
 # returns None if header is invalid
 def get_jwt_user(header):


### PR DESCRIPTION
This is the vogelnest part of the user sign up process. This is still work in progress. I will add these functionalities (but not tonight :-)). For some functionalities like add inactive pending or the group owner notification, I need to split up / add some API functions so that I can e.g. research the group owners from within the code.

- [x] Throw 500 if the user signs up for a non existent Lokalgruppe
- [x] Request for Allgemein (the present codebase treats the allgemein joining a little bit different to the legacy codebase)
- [x] Request for ones own LG
- [x] Notification of specific LG administrator

We need to at least perform these tests before deploying the PR:
- [ ] Check if mailboxes are created (and forwarding???)
- [ ] Check if the right people are correctly notified and can enable the user